### PR TITLE
implement, GetMessage and Verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,46 @@
 
 ## GetMessage
 
-> `curl --location --request GET 'http://localhost:1323/get_message'`
+generate a random message.
+
+for now, it is a dummy deterministic message generator seeded by caller identifier.
+
+to be improved...
+
+* request example
+
+	curl --location --request GET 'http://localhost:1323/get_message' \
+		--header 'Public-Key: 0x04cb883652f0337949621acaf4225410b912ca9cde1d12695b67aec1c78ff58e433fd374dc255833ac295df42f459245e80c389d6016aa62555af2e88c97e4b815'
+all fields in hex format
+
+* response example
+
+	{
+		"message": "0x4773b5629666dd72a586d96529aeaadd8fa33971cd66fee19329e75c869f626d"
+	}
+all fields in hex format
 
 
 ## Verify
 
-> `curl --location --request POST 'http://localhost:1323/verify' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "address": "some address",
-    "signedMessage": "some signed message"
-}'`
+verify if the signed message is indeed signed by the owner of the private key to the address
 
+* request example
+
+	curl --location --request POST 'http://localhost:1323/verify' \
+		--header 'Public-Key: 0x04cb883652f0337949621acaf4225410b912ca9cde1d12695b67aec1c78ff58e433fd374dc255833ac295df42f459245e80c389d6016aa62555af2e88c97e4b815' \
+		--header 'Content-Type: application/json' \
+		--data-raw '{
+    		"address": "0x06A85B71941e44B6b7A256042aE0319372282803",
+    		"signedMessage": "0x6c2324f62e5f5428c3819753593c6a3ddf7fc631b0a87daf819c55b0ca7d77ea22d44e90d11db9dd06c3e88e89585f438d2b80d48fe7a11c8a4971af6b2a4a5200"
+		}'
+all fields in hex format
+
+* response example
+
+	{
+	    "verified": true
+	}
 
 
 
@@ -29,19 +57,19 @@ generate private / public key pair, and also derive address
 
 this is for experiment convenience only. in reality you probably will not generate keys by calling external APIs
 
-request example
+* request example
 
 	curl --location --request POST 'http://localhost:1323/generate_key' \
 		--header 'Content-Type: application/json'
 
-response example
-all fields in hex format
+* response example
 
 	{
 	    "privateKey": "0x33c0f3bd9a866ab7558d6c52a98997f9c32d6774d9511eb1fa84d9deb4b39c43",
 	    "publicKey": "0x04cb883652f0337949621acaf4225410b912ca9cde1d12695b67aec1c78ff58e433fd374dc255833ac295df42f459245e80c389d6016aa62555af2e88c97e4b815",
 	    "address": "0x06A85B71941e44B6b7A256042aE0319372282803"
 	}
+all fields in hex format
 
 
 ## Sign
@@ -49,25 +77,22 @@ sign message using private key
 
 this is for experiment convenience only. in reality you probably will not sign message by calling external APIs
 
-request example
-
-all fields in hex format
+* request example
 
 	curl --location --request POST 'http://localhost:1323/sign' \
 		--header 'Content-Type: application/json' \
-		--header 'public-key: 0x04cb883652f0337949621acaf4225410b912ca9cde1d12695b67aec1c78ff58e433fd374dc255833ac295df42f459245e80c389d6016aa62555af2e88c97e4b815' \
 		--data-raw '{
     		"message": "0x4773b5629666dd72a586d96529aeaadd8fa33971cd66fee19329e75c869f626d",
     		"privateKey": "0x33c0f3bd9a866ab7558d6c52a98997f9c32d6774d9511eb1fa84d9deb4b39c43"
 		}'	
-
-response example
-
 all fields in hex format
+
+* response example
 
 	{
 	    "signedMessage": "0x6c2324f62e5f5428c3819753593c6a3ddf7fc631b0a87daf819c55b0ca7d77ea22d44e90d11db9dd06c3e88e89585f438d2b80d48fe7a11c8a4971af6b2a4a5200"
 	}
+all fields in hex format
 
 
 # reference

--- a/common/constant.go
+++ b/common/constant.go
@@ -1,0 +1,6 @@
+package common
+
+const (
+	// PublicKey ...
+	PublicKey = "Public-Key"
+)

--- a/handlers/getmessage.go
+++ b/handlers/getmessage.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"myapp/common"
+	"myapp/util"
 	"net/http"
 
 	"github.com/labstack/echo"
@@ -13,11 +15,18 @@ type GetMessageResponse struct {
 
 // GetMessage ...
 func GetMessage(c echo.Context) error {
-
-	// TODO
-	resp := &GetMessageResponse{
-		Message: "random_message",
+	publicKey := util.LoadRequestHeader(c, common.PublicKey)
+	if len(publicKey) == 0 {
+		c.Logger().Warn("empty publicKey")
+		return c.JSON(http.StatusBadRequest, nil)
 	}
+	c.Logger().Debugf("publicKey: %s", publicKey)
 
-	return c.JSON(http.StatusNotImplemented, resp)
+	msg := util.RandomMessage(publicKey) // publicKey as seed for now
+	c.Logger().Debugf("msg: %s", msg)
+
+	resp := &GetMessageResponse{
+		Message: msg,
+	}
+	return c.JSON(http.StatusOK, resp)
 }

--- a/util/random.go
+++ b/util/random.go
@@ -1,0 +1,10 @@
+package util
+
+import "github.com/ethereum/go-ethereum/crypto"
+
+// RandomMessage ...
+func RandomMessage(seed string) string {
+	// dummy random message generator
+	// TODO refactor later
+	return crypto.Keccak256Hash([]byte(seed)).Hex()
+}


### PR DESCRIPTION
`GetMessage` applies dummy logic to generate a "random" message that is determined by caller identifier (e.g. public key).

`Verify` verifies if the signedMessage is indeed signed by the private key to the address.

for now, require the request header to contain a `Public-Key` field, to be used for generating "random" message, can be improved later...

`GetMessage` example
<img width="715" alt="Screen Shot 2022-05-29 at 21 11 53" src="https://user-images.githubusercontent.com/1891275/170871280-1647c4ab-139e-49f4-a66e-2adefd797c46.png">

`Verify` example
<img width="703" alt="Screen Shot 2022-05-29 at 21 11 26" src="https://user-images.githubusercontent.com/1891275/170871286-dfb75888-3018-4b1e-9345-94005c268562.png">